### PR TITLE
Fix alpine 3.8 gh command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,8 @@ ARG ALPINE_VERSION=3.11
 # The official github-cli is not available for alpine <3.13
 FROM alpine:3.14 as gh-downloader
 
-# WORKDIR gh
-
 RUN apk update \
-  && apk fetch github-cli
+  && apk fetch --no-cache github-cli
 
 # ========================================
 FROM alpine:${ALPINE_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,15 @@
 ARG ALPINE_VERSION=3.11
+
+# ========================================
+# The official github-cli is not available for alpine <3.13
+FROM alpine:3.14 as gh-downloader
+
+# WORKDIR gh
+
+RUN apk update \
+  && apk fetch github-cli
+
+# ========================================
 FROM alpine:${ALPINE_VERSION}
 ARG ALPINE_VERSION=3.11
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,10 @@ RUN rosdep init \
   && sed -i -e 's|ros/rosdistro/master|alpine-ros/rosdistro/alpine-custom-apk|' \
     /etc/ros/rosdep/sources.list.d/20-default.list
 
-# Install github-cli (<3.13 doesn't have github-cli package)
-RUN apk add github-cli \
-  || apk add --repository https://dl-cdn.alpinelinux.org/alpine/v3.14/community github-cli
+COPY --from=gh-downloader github-cli*.apk .
+
+RUN apk add github-cli*.apk \
+  && rm -f github-cli*.apk
 
 ENV HOME="/root"
 


### PR DESCRIPTION
This PR fixes the issue that occurred in https://github.com/seqsense/aports-ros-updater/actions/runs/3510455566/jobs/5880267895#step:5:434
On `alpine 3.8`, the `github-cli` package is available but does not install the `gh` command from https://github.com/cli/cli. Instead it installs https://github.com/jsmits/github-cli (see https://git.alpinelinux.org/aports/tree/community/github-cli/APKBUILD?h=3.8-stable).