### PR TITLE
Drop Melodic and Noetic-3.11

### DIFF
--- a/.github/workflows/update.impl.yml
+++ b/.github/workflows/update.impl.yml
@@ -10,10 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - ROS_DISTRO=melodic ALPINE_VERSION=3.8 ROS_PYTHON_VERSION=2
-          - ROS_DISTRO=noetic ALPINE_VERSION=3.11 ROS_PYTHON_VERSION=3
-          - ROS_DISTRO=noetic ALPINE_VERSION=3.14 ROS_PYTHON_VERSION=3
-          - ROS_DISTRO=noetic ALPINE_VERSION=3.17 ROS_PYTHON_VERSION=3
+          - ROS_DISTRO=noetic ALPINE_VERSION=3.14
+          - ROS_DISTRO=noetic ALPINE_VERSION=3.17
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
-ARG ALPINE_VERSION=3.11
+ARG ALPINE_VERSION=3.14
 
 # ========================================
-# The official github-cli is not available for alpine <3.13
-FROM alpine:3.14 as gh-downloader
+FROM alpine:${ALPINE_VERSION} as gh-downloader
 
 RUN apk update \
   && apk fetch --no-cache github-cli
 
 # ========================================
 FROM alpine:${ALPINE_VERSION}
-ARG ALPINE_VERSION=3.11
+ARG ALPINE_VERSION=3.14
 
 RUN apk add --no-cache python3 py3-pip py3-yaml git curl findutils \
   && pip3 install \


### PR DESCRIPTION
Melodic is EOL-ed
Alpine 3.11 is EOL-ed in 2020

### Related PRs
- https://github.com/alpine-ros/alpine-ros/pull/27
- https://github.com/alpine-ros/ros-abuild-docker/pull/161
- https://github.com/seqsense/aports-ros-updater/pull/68
- https://github.com/seqsense/aports-ros-experimental/pull/819