### PR TITLE
Restore Melodic update

### DIFF
--- a/.github/workflows/update.impl.yml
+++ b/.github/workflows/update.impl.yml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         env:
+          - ROS_DISTRO=melodic ALPINE_VERSION=3.8 ROS_PYTHON_VERSION=2
           - ROS_DISTRO=noetic ALPINE_VERSION=3.14
           - ROS_DISTRO=noetic ALPINE_VERSION=3.17
     steps:


### PR DESCRIPTION
Melodic EOL seems be May 2023 (it was originally April) and may have the last sync before EOL.

https://github.com/seqsense/aports-ros-experimental/pull/824