### PR TITLE
Remove rosserial_test and add rosserial_server

### DIFF
--- a/package.list.ros1
+++ b/package.list.ros1
@@ -29,7 +29,7 @@ ros_tutorials
 rosbag_snapshot
 rosbridge_suite
 rosserial
-rosserial_test
+rosserial_server
 urg_node
 urg_stamped
 usb_cam


### PR DESCRIPTION
`rosserial_test` is not released to rosdistro.
Add `rosserial_server` to run `rosserial_test`.