### PR TITLE
Drop alpine 3.17

### DIFF
--- a/.github/workflows/update.impl.yml
+++ b/.github/workflows/update.impl.yml
@@ -10,7 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - ROS_DISTRO=humble ALPINE_VERSION=3.17 ROS_DISTRIBUTION_TYPE=ros2
           - ROS_DISTRO=humble ALPINE_VERSION=3.20 ROS_DISTRIBUTION_TYPE=ros2
           - ROS_DISTRO=jazzy ALPINE_VERSION=3.20 ROS_DISTRIBUTION_TYPE=ros2
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1
 
-ARG ALPINE_VERSION=3.17
+ARG ALPINE_VERSION=3.20
 
 # ========================================
 FROM alpine:${ALPINE_VERSION}
-ARG ALPINE_VERSION=3.17
+ARG ALPINE_VERSION=3.20
 
 RUN echo "http://alpine-ros.seqsense.org/v${ALPINE_VERSION}/backports" >> /etc/apk/repositories
 COPY <<EOF /etc/apk/keys/builder@alpine-ros-experimental.rsa.pub
@@ -29,8 +29,7 @@ RUN apk add --no-cache \
     py3-rosinstall-generator \
     py3-yaml \
     python3 \
-  && pip3 install $([ "${ALPINE_VERSION}" != '3.17' ] && echo -n '--break-system-packages') \
-    git+https://github.com/alpine-ros/ros-abuild-docker.git
+  && pip3 install --break-system-packages git+https://github.com/alpine-ros/ros-abuild-docker.git
 
 RUN rosdep init \
   && sed -i -e 's|ros/rosdistro/master|alpine-ros/rosdistro/alpine-custom-apk|' \


### PR DESCRIPTION
Alpine 3.17 is already EOL and we have [ros2 humble for 3.20](https://github.com/seqsense/aports-ros-experimental/pull/1019). So we can just drop support for 3.17.